### PR TITLE
Use mise-action for GitHub Actions workflows

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,18 @@
+name: Setup tools
+description: Setup development tools using mise
+runs:
+  using: composite
+  steps:
+    - name: Setup mise
+      uses: jdx/mise-action@5cb1df66ed5e1fb3c670ea0b62fd17a76979826a # v2.3.1
+      with:
+        experimental: true
+    - name: Cache Go modules
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,16 +8,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
-        with:
-          go-version-file: go.mod
+      - uses: ./.github/actions/setup
       - run: go build
 
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
-      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
-        with:
-          go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
+      - uses: ./.github/actions/setup
+      - run: golangci-lint run

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
-        with:
-          go-version-file: go.mod
+      - uses: ./.github/actions/setup
 
-      - uses: goreleaser/goreleaser-action@5fdedb94abba051217030cc86d4523cf3f02243d # v4.6.0
-        with:
-          args: release --rm-dist
+      - run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Migrate GitHub Actions workflows to use jdx/mise-action for tool setup
- Add composite action for centralized tool management
- Improve CI performance with Go modules caching

## Changes
- **New**: Create `.github/actions/setup/action.yml` composite action using mise-action
- **Update**: Replace individual setup actions (setup-go, golangci-lint-action, goreleaser-action) with composite action
- **Improve**: Add Go modules caching with actions/cache for faster builds
- **Fix**: Update goreleaser command from deprecated `--rm-dist` to `--clean`

## Benefits
- Consistent tool versioning between development and CI environments
- Simplified workflow maintenance with centralized setup
- Faster CI builds with Go modules caching
- Reduced workflow complexity and duplication

## Test plan
- [ ] CI workflow builds successfully
- [ ] Lint workflow runs without errors
- [ ] Release workflow can be triggered (manual test on merge)

🤖 Generated with [Claude Code](https://claude.ai/code)